### PR TITLE
Restore snapshots in OnEarlyUpdate()

### DIFF
--- a/com.unity.kinematica/Runtime/SnapshotDebugger/Debugger.cs
+++ b/com.unity.kinematica/Runtime/SnapshotDebugger/Debugger.cs
@@ -274,7 +274,6 @@ namespace Unity.SnapshotDebugger
 
         void OnEarlyUpdate()
         {
-
             if (IsState(State.Rewind))
             {
                 var snapshot = _storage.Retrieve(rewindTime);

--- a/com.unity.kinematica/Runtime/SnapshotDebugger/Debugger.cs
+++ b/com.unity.kinematica/Runtime/SnapshotDebugger/Debugger.cs
@@ -274,7 +274,20 @@ namespace Unity.SnapshotDebugger
 
         void OnEarlyUpdate()
         {
-            if (!rewind && !_wasRewinding)
+
+            if (IsState(State.Rewind))
+            {
+                var snapshot = _storage.Retrieve(rewindTime);
+
+                if (snapshot != null)
+                {
+                    time = snapshot.startTimeInSeconds;
+                    deltaTime = snapshot.durationInSeconds;
+
+                    registry.RestoreSnapshot(snapshot);
+                }
+            }
+            else if (!_wasRewinding)
             {
                 deltaTime = Time.deltaTime;
             }
@@ -300,18 +313,6 @@ namespace Unity.SnapshotDebugger
                 }
 
                 _wasRewinding = false;
-            }
-            else if (IsState(State.Rewind))
-            {
-                var snapshot = _storage.Retrieve(rewindTime);
-
-                if (snapshot != null)
-                {
-                    time = snapshot.startTimeInSeconds;
-                    deltaTime = snapshot.durationInSeconds;
-
-                    registry.RestoreSnapshot(snapshot);
-                }
             }
         }
 


### PR DESCRIPTION
Addresses #1 

Change how snapshots are restored when rewinding in the snapshot debugger such that snapshots are restored at the beginning of `OnEarlyUpdate()`, rather than being restored in `OnPreUpdate()`. This ensures that any logic running in `OnEarlyUpdate()` sees the restored world state and the correct delta time.